### PR TITLE
[CI] Use `latexmk` instead of manual pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,11 @@ jobs:
         run: |
           set -ex
           cd spec
-          pdflatex vt-good-image-protocol.tex
-          pdflatex vt-good-image-protocol.tex # second run
+          latexmk -pdflatex vt-good-image-protocol
       - name: "Uploading PDF"
         uses: actions/upload-artifact@v2
         with:
-          name: my-artifact
+          name: spec
           path: spec/vt-good-image-protocol.pdf
           if-no-files-found: error
 
@@ -51,6 +50,6 @@ jobs:
       - name: "Uploading markdown"
         uses: actions/upload-artifact@v2
         with:
-          name: my-artifact
+          name: spec
           path: spec/vt-good-image-protocol.md
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,11 @@ jobs:
         run: |
           set -ex
           cd spec
-          pdflatex vt-good-image-protocol.tex
-          pdflatex vt-good-image-protocol.tex # second run
+          latexmk -pdflatex vt-good-image-protocol
       - name: "Uploading PDF"
         uses: actions/upload-artifact@v2
         with:
-          name: my-artifact
+          name: spec
           path: spec/vt-good-image-protocol.pdf
           if-no-files-found: error
 
@@ -46,7 +45,7 @@ jobs:
       - name: "Uploading markdown"
         uses: actions/upload-artifact@v2
         with:
-          name: my-artifact
+          name: spec
           path: spec/vt-good-image-protocol.md
           if-no-files-found: error
 
@@ -60,7 +59,7 @@ jobs:
       - name: fetch release artifacts
         uses: actions/download-artifact@v2
         with:
-          name: my-artifact
+          name: spec
       # -------------------------------------------------------------
       - name: Set Output Variables
         id: set_env_var


### PR DESCRIPTION
Documents growing in size may eventually hit a barrier that the compilation falls apart "magically" because the build script forgets to include calls to `bibtex` or `mkglossary` or whatever. `latexmk` takes care of iteratively running the tools in the right order automatically (based on the document structure) even if packages that require build system support change or get introduced into the pipeline.